### PR TITLE
Qi, Karma: Fixed extract_sig signature

### DIFF
--- a/include/boost/spirit/home/support/nonterminal/extract_param.hpp
+++ b/include/boost/spirit/home/support/nonterminal/extract_param.hpp
@@ -84,7 +84,8 @@ namespace boost { namespace spirit { namespace detail
     struct make_function_type : mpl::identity<T()> {};
 
     ///////////////////////////////////////////////////////////////////////////
-    template <typename Types, typename Encoding, typename Domain>
+    template <typename Types, typename Encoding = unused_type
+      , typename Domain = unused_type>
     struct extract_sig
     {
         typedef typename


### PR DESCRIPTION
Since e34a955f2fbbf374870dee3329f89805cd775e6c commit `extract_sig`
requires all the parameters to be specified, but not all usages was
changes, what leads to missing template arguments error.

This patch makes those parameters optional again.
