### PR TITLE
Qi.Tests: Wrap `r1 = r1 | eps` with `SPIRIT_NO_COMPILE_CHECK` macro

### DIFF
--- a/test/qi/alternative.cpp
+++ b/test/qi/alternative.cpp
@@ -240,12 +240,15 @@ main()
     }
 
     {
+#ifdef SPIRIT_NO_COMPILE_CHECK
         //compile test only (bug_march_10_2011_8_35_am)
+        // TODO: does not work as intended with std <= c++03
         typedef boost::variant<double, std::string> value_type;
 
         using boost::spirit::qi::rule;
         using boost::spirit::qi::eps;
         rule<std::string::const_iterator, value_type()> r1 = r1 | eps;
+#endif
     }
 
     {


### PR DESCRIPTION
Logic of the test is to prevent `r1 = r1 | eps` construct, but
currently because of it `b2` fails to compile `alternative.cpp`
with default parameters. This behaviour spoils Boost Regression
test matrix, and prevents other tests in that file to be run.

I have wrapped the case with `SPIRIT_NO_COMPILE_CHECK` like it
has been done in `char1.cpp` and `sequence.cpp` tests.
